### PR TITLE
GCI-82: Add language support and improve label text

### DIFF
--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -1,6 +1,33 @@
 ${project.parent.artifactId}.title=Data Import Tool Module
 ${project.parent.artifactId}.manage=Manage module
 
+${project.parent.artifactId}.configureMigrationSettings=Configure Migration Settings
+${project.parent.artifactId}.matchFileData=Matching File Data
+${project.parent.artifactId}.targetDatabase=Target Database
+${project.parent.artifactId}.sourceDatabase=Source Database
+${project.parent.artifactId}.migrationOptions=Migration Options
+
+${project.parent.artifactId}.fileName=File name
+${project.parent.artifactId}.fileNamePopup=Fill in a file name (without the file type)
+${project.parent.artifactId}.fileType=File type
+${project.parent.artifactId}.fileTypePopup=Fill in a file type (must be xls)
+${project.parent.artifactId}.fileLocation=File location
+${project.parent.artifactId}.fileLocationPopup=Enter file location
+${project.parent.artifactId}.username=Username
+${project.parent.artifactId}.usernamePopup=Enter a username of a user with database privileges
+${project.parent.artifactId}.password=Password
+${project.parent.artifactId}.passwordPopup=Enter the password of the user with database privileges
+${project.parent.artifactId}.databaseDriver=Database driver
+${project.parent.artifactId}.databaseDriverPopup=Enter the database driver
+${project.parent.artifactId}.databaseName=Database name
+${project.parent.artifactId}.databaseNamePopup=Enter the database name
+${project.parent.artifactId}.databaseLocation=Database location
+${project.parent.artifactId}.databaseLocationPopup=Enter the database location
+${project.parent.artifactId}.allowCommit=Allow commit
+${project.parent.artifactId}.resetProcess=Reset process
+${project.parent.artifactId}.treeLimit=Tree limit
+${project.parent.artifactId}.startMigration=Start Migration
+
 common.separator=.......................................................................
 
 #ERROR MESSAGES

--- a/api/src/main/resources/messages_es.properties
+++ b/api/src/main/resources/messages_es.properties
@@ -1,1 +1,65 @@
+${project.parent.artifactId}.title=Herramienta de Importe de Datos
+${project.parent.artifactId}.manage=Administrar módulo
 
+${project.parent.artifactId}.configureMigrationSettings=Configurar Opciones de Migración
+${project.parent.artifactId}.matchFileData=Datos del archivo
+${project.parent.artifactId}.targetDatabase=Base de Datos Objetiva
+${project.parent.artifactId}.sourceDatabase=Base de Datos Fuente
+${project.parent.artifactId}.migrationOptions=Opciones de Migración
+
+${project.parent.artifactId}.fileName=Nombre del archivo
+${project.parent.artifactId}.fileNamePopup=Introduzca el nombre del archivo (sin la extensión)
+${project.parent.artifactId}.fileType=Extensión del archivo
+${project.parent.artifactId}.fileTypePopup=Introduzca la extensión del archivo (debe ser xls)
+${project.parent.artifactId}.fileLocation=Localización del archivo
+${project.parent.artifactId}.fileLocationPopup=Introduzca la localización del archivo
+${project.parent.artifactId}.username=Nombre de usuario
+${project.parent.artifactId}.usernamePopup=Introduzca el nombre de un usuario con privilegios relacionados con la base de datos
+${project.parent.artifactId}.password=Cortaseña de usuario
+${project.parent.artifactId}.passwordPopup=Introduzca la cortaseña del usuario con privilegios relacionados con la base de datos
+${project.parent.artifactId}.databaseDriver=Controlador (driver)
+${project.parent.artifactId}.databaseDriverPopup=Introduzca el controlador (driver) de la base de datos
+${project.parent.artifactId}.databaseName=Nombre
+${project.parent.artifactId}.databaseNamePopup=Introduzca el nombre de la base de datos
+${project.parent.artifactId}.databaseLocation=Localización
+${project.parent.artifactId}.databaseLocationPopup=Introduzca la localización de la base de datos
+${project.parent.artifactId}.allowCommit=Permitir commit
+${project.parent.artifactId}.resetProcess=Reiniciar proceso
+${project.parent.artifactId}.treeLimit=Límite de árboles
+${project.parent.artifactId}.startMigration=Comenzar Migración
+
+common.separator=.......................................................................
+
+#ERROR MESSAGES
+ERR001=The mapping must have a default value
+ERR002=The mapping datatype on left is not compatible with the datatype on right
+ERR003=The datatype in the left side must be INT for default value AI
+ERR004=The datatype in the right side must be logic (true, false) for default value AI/SKIP/TRUE or AI/SKIP/FALSE
+ERR005=The default value SKIP cannot be applied for match with right side required
+ERR006=The left side datatype must be INT compatible for PK match
+ERR007=The left side datatype must be required for PK match
+ERR008=The sequence value must be N/A for direct reference
+ERR009=The sequence value must not be N/A for indirect reference
+ERR010=The sequence value of an L-Reference must belong to the same tuple
+ERR011=The REFERENCE TABLE of an indirect reference must be the same as the REFERENCED TABLE of its predecessor
+ERR012=The default value cannot be NULL for a match with left side required
+ERR013=The mapping with default value TOP must not have a right side
+ERR014=The mapping with default value SKIP must have a right side
+ERR015=The tuple bust have an L-Reference with its parent tuple
+ERR016=The mapping with default value NOW must have a a left side datatype equal to DATE or DATETIME
+ERR017=Tuple must have a PK match
+ERR018=PK match must have R-References
+ERR019=Tuple must have L-References with its direct parent tuple
+
+#INFO MESSAGES
+INF001=started...
+INF002=completed with success
+INF003=completed with warnings
+INF004=tuples affected
+INF005=matches affected
+INF006=warning(s)
+INF007=tree(s) affected
+
+#WARNING MESSAGES
+WAR001=The datatypes of the two sides are only compatible from right to left. The data will be transformed if necessary
+WAR002= The size of the left side of the match is lower than the size of the right side of the match

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -43,6 +43,8 @@
 	<messages>
 		<lang>en</lang>
 		<file>messages.properties</file>
+		<lang>es</lang>
+		<file>messages_es.properties</file>
 	</messages>
 	<!-- /Internationalization -->
 	<privilege>

--- a/omod/src/main/webapp/addMigrationSettings.jsp
+++ b/omod/src/main/webapp/addMigrationSettings.jsp
@@ -8,109 +8,144 @@
 
 <form:form commandName="dit" method="post">
 <form:errors />
-<td colspan="2"><h2>Add Migration Settings</h2></td>
+<td colspan="2"><h2><spring:message code="dataimporttool.configureMigrationSettings" /></h2></td>
 	<fieldset>
-        <legend>Matching File Data</legend>
+        <legend><spring:message code="dataimporttool.matchFileData" /></legend>
 		<div id="block">
-            <td><form:label path="matchFile">Matching File Name</form:label></td>
+            <td><form:label path="matchFile"><spring:message code="dataimporttool.fileName" /></form:label></td>
             <td><form:input path="matchFile" /></td> 
             <form:errors path="matchFile" />
             <span class="appear">
-            <p>Fill in a file name (without file type)</p>
+            <p><spring:message code="dataimporttool.fileNamePopup" /></p>
             </span>
         </div>
 		<div id="block">
-            <td><form:label path="matchFormat">Match File Type</form:label></td>
+            <td><form:label path="matchFormat"><spring:message code="dataimporttool.fileType" /></form:label></td>
             <td><form:input path="matchFormat" /></td> 
             <form:errors path="matchFormat" />
             <span class="appear">
-            <p>Fill in a file type of the file (it should be xls).</p>
+            <p><spring:message code="dataimporttool.fileTypePopup" /></p>
             </span>
         </div>
 		<div id="block">
-            <td><form:label path="matchLocation">Matching File Location</form:label></td>
+            <td><form:label path="matchLocation"><spring:message code="dataimporttool.fileLocation" /></form:label></td>
             <td><form:input path="matchLocation" /></td> 
             <form:errors path="matchLocation" />
+            <span class="appear">
+            <p><spring:message code="dataimporttool.fileLocationPopup" /></p>
+            </span>
         </div>
 	</fieldset>
 	<fieldset>
-        <legend>Target Database Data</legend>
+        <legend><spring:message code="dataimporttool.targetDatabase" /></legend>
 		<div id="block">
-            <td><form:label path="leftUserName">User Name</form:label></td>
+            <td><form:label path="leftUserName"><spring:message code="dataimporttool.username" /></form:label></td>
             <td><form:input path="leftUserName" /></td>
+            <span class="appear">
+            <p><spring:message code="dataimporttool.usernamePopup" /></p>
+            </span>
         </div>
 	
 		<div id="block">
-            <td><form:label path="leftPassword">Password</form:label></td>
+            <td><form:label path="leftPassword"><spring:message code="dataimporttool.password" /></form:label></td>
             <td><form:input path="leftPassword" /></td>
+            <span class="appear">
+            <p><spring:message code="dataimporttool.passwordPopup" /></p>
+            </span>
         </div>
 	
 		<div id="block">
-            <td><form:label path="leftDbDriver">Database Driver</form:label></td>
+            <td><form:label path="leftDbDriver"><spring:message code="dataimporttool.databaseDriver" /></form:label></td>
             <td><form:input path="leftDbDriver" /></td> 
             <form:errors path="leftDbDriver" />
+            <span class="appear">
+            <p><spring:message code="dataimporttool.databaseDriverPopup" /></p>
+            </span>
         </div>
 		
 		<div id="block">
-            <td><form:label path="leftDbName">Database Name</form:label></td>
+            <td><form:label path="leftDbName"><spring:message code="dataimporttool.databaseName" /></form:label></td>
             <td><form:input path="leftDbName" /></td> 	
             <form:errors path="leftDbName" /><br>
+            <span class="appear">
+            <p><spring:message code="dataimporttool.databaseNamePopup" /></p>
+            </span>
         </div>
 		
 		<div id="block">
-            <td><form:label path="leftDbLocation">Database Location</form:label></td>
+            <td><form:label path="leftDbLocation"><spring:message code="dataimporttool.databaseLocation" /></form:label></td>
             <td><form:input path="leftDbLocation" /></td> 
             <form:errors path="leftDbLocation" />
+            <span class="appear">
+            <p><spring:message code="dataimporttool.databaseLocationPopup" /></p>
+            </span>
         </div>
 	</fieldset>
 	<fieldset>
-        <legend>Source Database</legend>		
+        <legend><spring:message code="dataimporttool.sourceDatabase" /></legend>		
 		<div id="block">
-            <td><form:label path="rightUserName">User Name</form:label></td>
+            <td><form:label path="rightUserName"><spring:message code="dataimporttool.username" /></form:label></td>
             <td><form:input path="rightUserName" /></td> 
             <form:errors path="rightUserName" />
+            <span class="appear">
+            <p><spring:message code="dataimporttool.usernamePopup" /></p>
+            </span>
         </div>
 		
 		<div id="block">
-            <td><form:label path="rightPassword">Password</form:label></td>
+            <td><form:label path="rightPassword"><spring:message code="dataimporttool.password" /></form:label></td>
             <td><form:input path="rightPassword" /></td>
+            <span class="appear">
+            <p><spring:message code="dataimporttool.passwordPopup" /></p>
+            </span>
         </div>
 		
 		<div id="block">
-            <td><form:label path="rightDbDriver">Database Driver</form:label></td>
+            <td><form:label path="rightDbDriver"><spring:message code="dataimporttool.databaseDriver" /></form:label></td>
             <td><form:input path="rightDbDriver" /></td>
             <form:errors path="rightDbDriver" />
+            <span class="appear">
+            <p><spring:message code="dataimporttool.databaseDriverPopup" /></p>
+            </span>
         </div>
 		
 		<div id="block">
-            <td><form:label path="rightDbName">Database Name</form:label></td>
+            <td><form:label path="rightDbName"><spring:message code="dataimporttool.databaseName" /></form:label></td>
             <td><form:input path="rightDbName" /></td> 
             <form:errors path="rightDbName" /><br>
-            </div>
+            <span class="appear">
+            <p><spring:message code="dataimporttool.databaseNamePopup" /></p>
+            </span>
+        </div>
 	
 		<div id="block">
-            <td><form:label path="rightDbLocation">Database Location</form:label></td>
+            <td><form:label path="rightDbLocation"><spring:message code="dataimporttool.databaseLocation" /></form:label></td>
             <td><form:input path="rightDbLocation" /></td> 
             <form:errors path="rightDbLocation" />
+            <span class="appear">
+            <p><spring:message code="dataimporttool.databaseLocationPopup" /></p>
+            </span>
         </div>
 	</fieldset>
     <fieldset>
-        <legend>Migration Options</legend>
+        <legend><spring:message code="dataimporttool.migrationOptions" /></legend>
 	 	<div id="box">
-            <td><form:label path="allowCommit">Allow Commit</form:label></td>
+            <td><form:label path="allowCommit"><spring:message code="dataimporttool.allowCommit" /></form:label></td>
             <form:checkbox path="allowCommit" value="true"/>
         </div>
   		<div id="box">
-            <form:label path="resetProcess">Reset Process</form:label></td>
+            <form:label path="resetProcess"><spring:message code="dataimporttool.resetProcess" /></form:label></td>
   		    <form:checkbox path="resetProcess" value="true"/>
         </div>  			
 		<div id="block">
-            <td><form:label path="treeLimit">Tree Limit</form:label></td>
+            <td><form:label path="treeLimit"><spring:message code="dataimporttool.treeLimit" /></form:label></td>
             <td><form:input path="treeLimit" /></td>
         </div>
 	</fieldset>
-	<div id="button"><td colspan="2"><input type="submit" value="Start Migration" ></td></div>
-
+    <spring:message code="dataimporttool.startMigration" var="startMigration" />
+    <div id="button">
+	<td colspan="2"><input type="submit" value="${startMigration}"></td>
+    </div>
 </form:form>
 </body>
 </html>


### PR DESCRIPTION
Adding language support improves the UI for users from different countries. In this commit language support is implemented with the spanish language included. Also, some label texts have been simplified and made easier to understand. There's a problem here though. The popup translations don't appear to be working. For example, `dataimporttool.fileLocationPopup` shows as "dataimporttool.fileLocationPopup" when it should show the translation for it. This only happens in the english translation, the spanish version works fine. I'm not sure about the reason of this behaviour but I don't think the implemention and translations are a problem.
