### PR TITLE
GCI-82: Fix #8 and add es, pt, it translations

### DIFF
--- a/api/src/main/resources/messages_es.properties
+++ b/api/src/main/resources/messages_es.properties
@@ -1,1 +1,75 @@
+${project.parent.artifactId}.title=Herramienta de importe de datos
+${project.parent.artifactId}.manage=Administrar módulo
 
+#Matching File Data
+${project.parent.artifactId}.addMigrationSettings=Configurar Opciones de Migración
+${project.parent.artifactId}.matchFileData=Datos del Archivo
+${project.parent.artifactId}.matchFile=Nombre del archivo
+${project.parent.artifactId}.matchFilePopUp=Introduzca el nombre del archivo (sin la extensión)
+${project.parent.artifactId}.matchFormat=Extensión del archivo
+${project.parent.artifactId}.matchFormatPopUp=Introduzca la extensión (debe ser xls).
+${project.parent.artifactId}.matchLocation=Localización del archivo
+
+#Database Information
+${project.parent.artifactId}.targetDbData=Base de Datos Objetiva
+${project.parent.artifactId}.sourceDbData=Base de Datos Fuente
+${project.parent.artifactId}.username=Nombre de usuario
+${project.parent.artifactId}.password=Cortaseña de usuario
+${project.parent.artifactId}.dbDriver=Controlador de base
+${project.parent.artifactId}.dbName=Nombre de base
+${project.parent.artifactId}.dbLocation=Localización de base
+
+#Migration Options
+${project.parent.artifactId}.migrationOptions=Opciones de Migración
+${project.parent.artifactId}.allowCommit=Permitir commit
+${project.parent.artifactId}.resetProcess=Reiniciar proceso
+${project.parent.artifactId}.treeLimit=Límite de árboles
+${project.parent.artifactId}.startMigration=Comenzar Migración
+
+${project.parent.artifactId}.migrationSuccess=Migration Success
+${project.parent.artifactId}.migrationError=Migration Error
+${project.parent.artifactId}.successLog=Data Migration Successful. View the Logs for Complete details!
+${project.parent.artifactId}.errorLog=Errors occured during Migration. Check the Logs.
+${project.parent.artifactId}.errorRef=Edit your migration settings or look on the guide.
+${project.parent.artifactId}.home= Home
+${project.parent.artifactId}.logs= Logs
+${project.parent.artifactId}.edit=Edit
+${project.parent.artifactId}.help=Help
+${project.parent.artifactId}.migrationProgress= Data Validation and Translation...
+${project.parent.artifactId}.running=Running
+
+common.separator=.......................................................................
+
+#ERROR MESSAGES
+ERR001=The mapping must have a default value
+ERR002=The mapping datatype on left is not compatible with the datatype on right
+ERR003=The datatype in the left side must be INT for default value AI
+ERR004=The datatype in the right side must be logic (true, false) for default value AI/SKIP/TRUE or AI/SKIP/FALSE
+ERR005=The default value SKIP cannot be applied for match with right side required
+ERR006=The left side datatype must be INT compatible for PK match
+ERR007=The left side datatype must be required for PK match
+ERR008=The sequence value must be N/A for direct reference
+ERR009=The sequence value must not be N/A for indirect reference
+ERR010=The sequence value of an L-Reference must belong to the same tuple
+ERR011=The REFERENCE TABLE of an indirect reference must be the same as the REFERENCED TABLE of its predecessor
+ERR012=The default value cannot be NULL for a match with left side required
+ERR013=The mapping with default value TOP must not have a right side
+ERR014=The mapping with default value SKIP must have a right side
+ERR015=The tuple bust have an L-Reference with its parent tuple
+ERR016=The mapping with default value NOW must have a a left side datatype equal to DATE or DATETIME
+ERR017=Tuple must have a PK match
+ERR018=PK match must have R-References
+ERR019=Tuple must have L-References with its direct parent tuple
+
+#INFO MESSAGES
+INF001=started...
+INF002=completed with success
+INF003=completed with warnings
+INF004=tuples affected
+INF005=matches affected
+INF006=warning(s)
+INF007=tree(s) affected
+
+#WARNING MESSAGES
+WAR001=The datatypes of the two sides are only compatible from right to left. The data will be transformed if necessary
+WAR002= The size of the left side of the match is lower than the size of the right side of the match

--- a/api/src/main/resources/messages_it.properties
+++ b/api/src/main/resources/messages_it.properties
@@ -1,30 +1,30 @@
-${project.parent.artifactId}.title=Data Import Tool Module
-${project.parent.artifactId}.manage=Manage module
+${project.parent.artifactId}.title=Quantità di dati strumento
+${project.parent.artifactId}.manage=Modulo Gestione
 
 #Matching File Data
-${project.parent.artifactId}.addMigrationSettings=Add Migration Settings
-${project.parent.artifactId}.matchFileData=Matching File Data
-${project.parent.artifactId}.matchFile=File name
-${project.parent.artifactId}.matchFilePopUp=Fill in a file name (without file type)
-${project.parent.artifactId}.matchFormat=File type
-${project.parent.artifactId}.matchFormatPopUp=Fill in a file type of the file (it should be xls).
-${project.parent.artifactId}.matchLocation=Matching File Location
+${project.parent.artifactId}.addMigrationSettings=Configurare Opzioni di migrazione
+${project.parent.artifactId}.matchFileData=Informazioni File
+${project.parent.artifactId}.matchFile=Nome file
+${project.parent.artifactId}.matchFilePopUp=Immettere il nome del file (senza l'estensione)
+${project.parent.artifactId}.matchFormat=Estensione file
+${project.parent.artifactId}.matchFormatPopUp=Immettere l'interno (deve essere xls).
+${project.parent.artifactId}.matchLocation=Posizione del file
 
 #Database Information
-${project.parent.artifactId}.targetDbData=Target Database Data
-${project.parent.artifactId}.sourceDbData=Source Database
-${project.parent.artifactId}.username=Username
-${project.parent.artifactId}.password=Password
-${project.parent.artifactId}.dbDriver=Database driver
-${project.parent.artifactId}.dbName=Database name
-${project.parent.artifactId}.dbLocation=Database location
+${project.parent.artifactId}.targetDbData=Base di dati obiettiva
+${project.parent.artifactId}.sourceDbData=Database di origine
+${project.parent.artifactId}.username=Nombre de usuario
+${project.parent.artifactId}.password=Nome utente
+${project.parent.artifactId}.dbDriver=Driver di database
+${project.parent.artifactId}.dbName=Nome database
+${project.parent.artifactId}.dbLocation=Database di localizzazione
 
 #Migration Options
-${project.parent.artifactId}.migrationOptions=Migration Options
-${project.parent.artifactId}.allowCommit=Allow commit
-${project.parent.artifactId}.resetProcess=Reset process
-${project.parent.artifactId}.treeLimit=Tree limit
-${project.parent.artifactId}.startMigration=Start Migration
+${project.parent.artifactId}.migrationOptions=Opzioni di migrazione
+${project.parent.artifactId}.allowCommit=Consentire commit
+${project.parent.artifactId}.resetProcess=Processo di riavvio
+${project.parent.artifactId}.treeLimit=Alberi Limit
+${project.parent.artifactId}.startMigration=Inizia migrazione
 
 ${project.parent.artifactId}.migrationSuccess=Migration Success
 ${project.parent.artifactId}.migrationError=Migration Error

--- a/api/src/main/resources/messages_pt.properties
+++ b/api/src/main/resources/messages_pt.properties
@@ -1,30 +1,30 @@
-${project.parent.artifactId}.title=Data Import Tool Module
-${project.parent.artifactId}.manage=Manage module
+${project.parent.artifactId}.title=Ferramenta de importação de dados
+${project.parent.artifactId}.manage=Administrar módulo
 
 #Matching File Data
-${project.parent.artifactId}.addMigrationSettings=Add Migration Settings
-${project.parent.artifactId}.matchFileData=Matching File Data
-${project.parent.artifactId}.matchFile=File name
-${project.parent.artifactId}.matchFilePopUp=Fill in a file name (without file type)
-${project.parent.artifactId}.matchFormat=File type
-${project.parent.artifactId}.matchFormatPopUp=Fill in a file type of the file (it should be xls).
-${project.parent.artifactId}.matchLocation=Matching File Location
+${project.parent.artifactId}.addMigrationSettings=Configurar opções de migração
+${project.parent.artifactId}.matchFileData=Dados de Arquivo
+${project.parent.artifactId}.matchFile=Nome do arquivo
+${project.parent.artifactId}.matchFilePopUp=Introduza o nome do arquivo ( sem a extensão)
+${project.parent.artifactId}.matchFormat=Extensão do arquivo
+${project.parent.artifactId}.matchFormatPopUp=Introduza a extensão (deve ser xls)
+${project.parent.artifactId}.matchLocation=Localização do arquivo
 
 #Database Information
-${project.parent.artifactId}.targetDbData=Target Database Data
-${project.parent.artifactId}.sourceDbData=Source Database
-${project.parent.artifactId}.username=Username
-${project.parent.artifactId}.password=Password
-${project.parent.artifactId}.dbDriver=Database driver
-${project.parent.artifactId}.dbName=Database name
-${project.parent.artifactId}.dbLocation=Database location
+${project.parent.artifactId}.targetDbData=Base de dados objetiva
+${project.parent.artifactId}.sourceDbData=Base de dados fonte
+${project.parent.artifactId}.username=Nome do usuário
+${project.parent.artifactId}.password=Senha do usuário
+${project.parent.artifactId}.dbDriver=Controlador de base
+${project.parent.artifactId}.dbName=Nome de base
+${project.parent.artifactId}.dbLocation=Localização de base
 
 #Migration Options
-${project.parent.artifactId}.migrationOptions=Migration Options
-${project.parent.artifactId}.allowCommit=Allow commit
-${project.parent.artifactId}.resetProcess=Reset process
-${project.parent.artifactId}.treeLimit=Tree limit
-${project.parent.artifactId}.startMigration=Start Migration
+${project.parent.artifactId}.migrationOptions=Opções de migração
+${project.parent.artifactId}.allowCommit=Permitir commit
+${project.parent.artifactId}.resetProcess=Reiniciar processo
+${project.parent.artifactId}.treeLimit=Limite de árvores
+${project.parent.artifactId}.startMigration=Começar migração
 
 ${project.parent.artifactId}.migrationSuccess=Migration Success
 ${project.parent.artifactId}.migrationError=Migration Error

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -40,9 +40,25 @@
 
 	<!-- Internationalization -->
 	<!-- All message codes should start with ${project.parent.artifactId}. -->
+	<!-- English -->
 	<messages>
 		<lang>en</lang>
 		<file>messages.properties</file>
+	</messages>
+	<!-- Spanish -->
+	<messages>
+		<lang>es</lang>
+		<file>messages_es.properties</file>
+	</messages>
+	<!-- Portuguese -->
+	<messages>
+		<lang>pt</lang>
+		<file>messages_pt.properties</file>
+	</messages>
+	<!-- Italian -->
+	<messages>
+		<lang>it</lang>
+		<file>messages_it.properties</file>
 	</messages>
 	<!-- /Internationalization -->
 	<privilege>

--- a/omod/src/main/webapp/addMigrationSettings.jsp
+++ b/omod/src/main/webapp/addMigrationSettings.jsp
@@ -12,8 +12,8 @@
 	<fieldset>
         <legend><spring:message code="dataimporttool.matchFileData" /></legend>
 		<div id="block">
-            <td><form:label path="matchFile"></form:label><spring:message code="dataimporttool.matchFile" /></td>
-            <td><form:input path="matchFile" /></td> 
+            <td><form:label path="matchFile"><spring:message code="dataimporttool.matchFile" /></form:label></td>
+            <td><form:input path="matchFile" /></td>
             <form:errors path="matchFile" />
             <span class="appear">
             <p><spring:message code="dataimporttool.matchFilePopUp" /></p>
@@ -24,7 +24,7 @@
             <td><form:input path="matchFormat" /></td> 
             <form:errors path="matchFormat" />
             <span class="appear">
-            <p>${project.parent.artifactId}.matchFormatPopUp</p>
+            <p><spring:message code="dataimporttool.matchFormatPopUp" /></p>
             </span>
         </div>
 		<div id="block">
@@ -47,13 +47,13 @@
 	
 		<div id="block">
             <td><form:label path="leftDbDriver"><spring:message code="dataimporttool.dbDriver" /></form:label></td>
-            <td><form:input path="leftDbDriver" /></td> 
+            <td><form:input path="leftDbDriver" /></td>
             <form:errors path="leftDbDriver" />
         </div>
 		
 		<div id="block">
             <td><form:label path="leftDbName"><spring:message code="dataimporttool.dbName" /></form:label></td>
-            <td><form:input path="leftDbName" /></td> 	
+            <td><form:input path="leftDbName" /></td>
             <form:errors path="leftDbName" /><br>
         </div>
 		


### PR DESCRIPTION
The original pull request was #7 but while it was in stand-by, another student made pull request #8 with the content from #7. You can tell it is derived from #7 because the title specifically says "Moved freetext to message.properties" though #7 message labels and logic are there when that was not the intention. The derivation made some items not work properly, this issue was addressed in this new pull request. For example, the file name label was not working because the form element was closed too soon which caused it to be indented. And also, I changed the message names to the original #7 names. While this is opensource and no one's code belongs to anyone, we are participating in GCI which means everything should be original. And please, if there is already a pull request focused in fixing or adding something, do NOT make another with the same objective and content. Anyways, on topic: I added translations for spanish and overrided #8 commits to match #7 while keeping #8's actual additions (comments, spacing). More translations for spanish are planned to be added soon.

A screenshot showing the spanish translations can be found here: http://i.imgur.com/IUTQyHz.png
