### PR TITLE
Bad css naming correctin

### DIFF
--- a/omod/src/main/webapp/error.jsp
+++ b/omod/src/main/webapp/error.jsp
@@ -23,7 +23,7 @@
             <br />
             <a href="#" onclick="history.go(-1)" class="button back"><i class="fa fa-pencil"></i><spring:message code="dataimporttool.edit" /></a>
             <a href="${pageContext.request.contextPath}/admin/maintenance/serverLog.form" class="button logs"><i class="fa fa-list"></i><spring:message code="dataimporttool.logs" /></a>
-            <a href="${pageContext.request.contextPath}/module/dataimporttool/help.form" class="button help"><i class="fa fa-info-circle"></i><spring:message code="dataimporttool.help" /></a>
+            <a href="${pageContext.request.contextPath}/module/dataimporttool/help.form" class="button btnhelp"><i class="fa fa-info-circle"></i><spring:message code="dataimporttool.help" /></a>
         </div>
     </div>
 </body>

--- a/omod/src/main/webapp/resources/css/component.css
+++ b/omod/src/main/webapp/resources/css/component.css
@@ -311,6 +311,9 @@ input[type=radio]:checked + label:after {
 .dialog .dialog-content a {
     color: white !important;
 }
+.dialog .dialog-content .button i {
+    padding-right: 7px;
+}
 .dialog .dialog-content .button.back {
     -moz-border-radius: 3px;
     -webkit-border-radius: 3px;
@@ -347,7 +350,7 @@ input[type=radio]:checked + label:after {
     max-width: 300px;
     text-decoration: none;
 }
-.dialog .dialog-content .button.help {
+.dialog .dialog-content .button.btnhelp {
     float: right;
     -moz-border-radius: 3px;
     -webkit-border-radius: 3px;

--- a/omod/src/main/webapp/status.jsp
+++ b/omod/src/main/webapp/status.jsp
@@ -20,7 +20,7 @@
             <p><spring:message code="dataimporttool.successLog" /></p>
             <br />
             <a href="${pageContext.request.contextPath}/" class="button back"><i class="fa fa-home"></i><spring:message code="dataimporttool.home" /></a>
-            <a href="${pageContext.request.contextPath}/module/dataimporttool/help.form" class="button help"><i class="fa fa-list"></i><spring:message code="dataimporttool.logs" /></a>
+            <a href="${pageContext.request.contextPath}/module/dataimporttool/help.form" class="button btnhelp"><i class="fa fa-list"></i><spring:message code="dataimporttool.logs" /></a>
         </div>
     </div>
 </body>


### PR DESCRIPTION
Correcting bad naming in css, There where two different things with same css class.
Before:
![photo_2016-01-18_23-18-39](https://cloud.githubusercontent.com/assets/10288864/12404378/30f18284-be3b-11e5-97a5-737ff6fe9895.jpg)
After:
![snimek obrazovky 54](https://cloud.githubusercontent.com/assets/10288864/12404377/30f0ce66-be3b-11e5-9603-96e3b9519508.png)
