### PR TITLE
GCI-84: Use target _blank and add pt, es, it translations with more details

### DIFF
--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -26,15 +26,16 @@ ${project.parent.artifactId}.resetProcess=Reset process
 ${project.parent.artifactId}.treeLimit=Tree limit
 ${project.parent.artifactId}.startMigration=Start Migration
 
-${project.parent.artifactId}.migrationSuccess=Migration Success
-${project.parent.artifactId}.migrationError=Migration Error
-${project.parent.artifactId}.successLog=Data Migration Successful. View the Logs for Complete details!
-${project.parent.artifactId}.errorLog=Errors occured during Migration. Check the Logs.
-${project.parent.artifactId}.errorRef=Edit your migration settings or look on the guide.
+#Migration Sucess, Error, and Progress
+${project.parent.artifactId}.migrationSuccess=MIGRATION SUCCESS
+${project.parent.artifactId}.migrationError=MIGRATION ERROR
+${project.parent.artifactId}.successLog=The data migration was successful. View the logs for the complete details!
+${project.parent.artifactId}.errorLog=Some errors have occurred during migration. Check the logs.
+${project.parent.artifactId}.errorRef=To fix this edit your migration settings. If you need help you can look on the help guide.
 ${project.parent.artifactId}.home= Home
 ${project.parent.artifactId}.logs= Logs
-${project.parent.artifactId}.edit=Edit
-${project.parent.artifactId}.help=Help
+${project.parent.artifactId}.edit= Edit
+${project.parent.artifactId}.help= Help
 ${project.parent.artifactId}.migrationProgress= Data Validation and Translation...
 ${project.parent.artifactId}.running=Running
 

--- a/api/src/main/resources/messages_es.properties
+++ b/api/src/main/resources/messages_es.properties
@@ -26,15 +26,16 @@ ${project.parent.artifactId}.resetProcess=Reiniciar proceso
 ${project.parent.artifactId}.treeLimit=Límite de árboles
 ${project.parent.artifactId}.startMigration=Comenzar Migración
 
-${project.parent.artifactId}.migrationSuccess=Migration Success
-${project.parent.artifactId}.migrationError=Migration Error
-${project.parent.artifactId}.successLog=Data Migration Successful. View the Logs for Complete details!
-${project.parent.artifactId}.errorLog=Errors occured during Migration. Check the Logs.
-${project.parent.artifactId}.errorRef=Edit your migration settings or look on the guide.
-${project.parent.artifactId}.home= Home
+#Migration Sucess, Error, and Progress
+${project.parent.artifactId}.migrationSuccess=MIGRACIÓN EXITOSA
+${project.parent.artifactId}.migrationError=MIGRACIÓN FALLIDA
+${project.parent.artifactId}.successLog=La migración fue un éxito. Vea los logs para los detalles completos!
+${project.parent.artifactId}.errorLog=Han ocurrido errores durante la migración. Vea los logs.
+${project.parent.artifactId}.errorRef=Para solucionar estos errores edite la configuración de la migración. Si necesita ayuda vea la guía de ayuda.
+${project.parent.artifactId}.home= Inicio
 ${project.parent.artifactId}.logs= Logs
-${project.parent.artifactId}.edit=Edit
-${project.parent.artifactId}.help=Help
+${project.parent.artifactId}.edit= Editar
+${project.parent.artifactId}.help= Ayuda
 ${project.parent.artifactId}.migrationProgress= Data Validation and Translation...
 ${project.parent.artifactId}.running=Running
 

--- a/api/src/main/resources/messages_it.properties
+++ b/api/src/main/resources/messages_it.properties
@@ -26,15 +26,16 @@ ${project.parent.artifactId}.resetProcess=Processo di riavvio
 ${project.parent.artifactId}.treeLimit=Alberi Limit
 ${project.parent.artifactId}.startMigration=Inizia migrazione
 
-${project.parent.artifactId}.migrationSuccess=Migration Success
-${project.parent.artifactId}.migrationError=Migration Error
-${project.parent.artifactId}.successLog=Data Migration Successful. View the Logs for Complete details!
-${project.parent.artifactId}.errorLog=Errors occured during Migration. Check the Logs.
-${project.parent.artifactId}.errorRef=Edit your migration settings or look on the guide.
-${project.parent.artifactId}.home= Home
+#Migration Sucess, Error, and Progress
+${project.parent.artifactId}.migrationSuccess=MIGRAZIONE DI SUCCESSO
+${project.parent.artifactId}.migrationError=LA MIGRAZIONE NON È RIUSCITA
+${project.parent.artifactId}.successLog=La migrazione ha avuto successo. Controllate i log per tutti i dettagli!
+${project.parent.artifactId}.errorLog=Ci sono verificati errori durante la migrazione. Vedere i log.
+${project.parent.artifactId}.errorRef=Per risolvere questi errori modificare migrazione delle impostazioni. Se hai bisogno di aiuto consultare la guida di aiuto.
+${project.parent.artifactId}.home= Iniziazione
 ${project.parent.artifactId}.logs= Logs
-${project.parent.artifactId}.edit=Edit
-${project.parent.artifactId}.help=Help
+${project.parent.artifactId}.edit= Modifica
+${project.parent.artifactId}.help= Aiuto
 ${project.parent.artifactId}.migrationProgress= Data Validation and Translation...
 ${project.parent.artifactId}.running=Running
 

--- a/api/src/main/resources/messages_pt.properties
+++ b/api/src/main/resources/messages_pt.properties
@@ -5,7 +5,7 @@ ${project.parent.artifactId}.manage=Administrar módulo
 ${project.parent.artifactId}.addMigrationSettings=Configurar opções de migração
 ${project.parent.artifactId}.matchFileData=Dados de Arquivo
 ${project.parent.artifactId}.matchFile=Nome do arquivo
-${project.parent.artifactId}.matchFilePopUp=Introduza o nome do arquivo ( sem a extensão)
+${project.parent.artifactId}.matchFilePopUp=Introduza o nome do arquivo (sem a extensão)
 ${project.parent.artifactId}.matchFormat=Extensão do arquivo
 ${project.parent.artifactId}.matchFormatPopUp=Introduza a extensão (deve ser xls)
 ${project.parent.artifactId}.matchLocation=Localização do arquivo
@@ -26,15 +26,16 @@ ${project.parent.artifactId}.resetProcess=Reiniciar processo
 ${project.parent.artifactId}.treeLimit=Limite de árvores
 ${project.parent.artifactId}.startMigration=Começar migração
 
-${project.parent.artifactId}.migrationSuccess=Migration Success
-${project.parent.artifactId}.migrationError=Migration Error
-${project.parent.artifactId}.successLog=Data Migration Successful. View the Logs for Complete details!
-${project.parent.artifactId}.errorLog=Errors occured during Migration. Check the Logs.
-${project.parent.artifactId}.errorRef=Edit your migration settings or look on the guide.
-${project.parent.artifactId}.home= Home
+#Migration Sucess, Error, and Progress
+${project.parent.artifactId}.migrationSuccess=MIGRAÇÃO EXITOSA
+${project.parent.artifactId}.migrationError=FALHA NA MIGRAÇÃO
+${project.parent.artifactId}.successLog=A migração foi exitosa - veja os logs para os detalhes completos!
+${project.parent.artifactId}.errorLog=Ocorreram erros durante a migração. Veja os logs para solucionar os erros.
+${project.parent.artifactId}.errorRef=Edite a configuração da migração. Se necessita ajuda veja a guia de ajuda.
+${project.parent.artifactId}.home= Inicio
 ${project.parent.artifactId}.logs= Logs
-${project.parent.artifactId}.edit=Edit
-${project.parent.artifactId}.help=Help
+${project.parent.artifactId}.edit= Editar
+${project.parent.artifactId}.help= Ajuda
 ${project.parent.artifactId}.migrationProgress= Data Validation and Translation...
 ${project.parent.artifactId}.running=Running
 

--- a/omod/src/main/webapp/error.jsp
+++ b/omod/src/main/webapp/error.jsp
@@ -8,7 +8,6 @@
 <openmrs:htmlInclude file="/moduleResources/dataimporttool/css/component.css"/>
 <openmrs:htmlInclude file="/moduleResources/dataimporttool/css/font-awesome.min.css"/>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<title>Migration Error!</title>
 </head>
 <body>
     <div align="center" class="dialog">
@@ -22,8 +21,8 @@
             <p><em><spring:message code="dataimporttool.errorRef" /></em></p>
             <br />
             <a href="#" onclick="history.go(-1)" class="button back"><i class="fa fa-pencil"></i><spring:message code="dataimporttool.edit" /></a>
-            <a href="${pageContext.request.contextPath}/admin/maintenance/serverLog.form" class="button logs"><i class="fa fa-list"></i><spring:message code="dataimporttool.logs" /></a>
-            <a href="${pageContext.request.contextPath}/module/dataimporttool/help.form" class="button btnhelp"><i class="fa fa-info-circle"></i><spring:message code="dataimporttool.help" /></a>
+            <a href="${pageContext.request.contextPath}/admin/maintenance/serverLog.form" target="_blank" class="button logs"><i class="fa fa-list"></i><spring:message code="dataimporttool.logs" /></a>
+            <a href="${pageContext.request.contextPath}/module/dataimporttool/help.form" target="_blank" class="button btnhelp"><i class="fa fa-info-circle"></i><spring:message code="dataimporttool.help" /></a>
         </div>
     </div>
 </body>

--- a/omod/src/main/webapp/status.jsp
+++ b/omod/src/main/webapp/status.jsp
@@ -8,7 +8,6 @@
 <openmrs:htmlInclude file="/moduleResources/dataimporttool/css/component.css"/>
 <openmrs:htmlInclude file="/moduleResources/dataimporttool/css/font-awesome.min.css"/>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<title>Migration Success!</title>
 </head>
 <body>
     <div align="center" class="dialog">
@@ -20,7 +19,7 @@
             <p><spring:message code="dataimporttool.successLog" /></p>
             <br />
             <a href="${pageContext.request.contextPath}/" class="button back"><i class="fa fa-home"></i><spring:message code="dataimporttool.home" /></a>
-            <a href="${pageContext.request.contextPath}/module/dataimporttool/help.form" class="button btnhelp"><i class="fa fa-list"></i><spring:message code="dataimporttool.logs" /></a>
+            <a href="${pageContext.request.contextPath}/module/dataimporttool/help.form" target="_blank" class="button btnhelp"><i class="fa fa-list"></i><spring:message code="dataimporttool.logs" /></a>
         </div>
     </div>
 </body>


### PR DESCRIPTION
**Changes**:
- Status and error buttons now use target _blank to open new tabs. Previously, if you were to click a button, it directed you to a href on the current tab. This was annoying for the user because if they tried to go back, the page wouldn't show.
- Add more details to the dialog text. The sentences were too straight foward.
- Dialog title text capitalized.
- Removed unnecessary titles on the JSP pages.
- Add translations for Portuguese, Spanish, and Italian. This makes DIT more user friendly for people who don't speak english.

There are some issues with the dialog buttons. If the text length in a button is longer than 4 the buttons size up and the padding is affected.

**Results**:

![a085](https://cloud.githubusercontent.com/assets/11695552/12426818/807b1656-beba-11e5-9002-9dd3b7676f8f.png)

![a086](https://cloud.githubusercontent.com/assets/11695552/12426817/80793eee-beba-11e5-8617-784a23c96fc8.png)

![a087](https://cloud.githubusercontent.com/assets/11695552/12426815/8074f3e8-beba-11e5-8a20-6f25c1700550.png)

![a088](https://cloud.githubusercontent.com/assets/11695552/12426816/807852a4-beba-11e5-9323-71223bee02d7.png)
